### PR TITLE
Update signature for get_id method

### DIFF
--- a/blogger-importer-blogitem.php
+++ b/blogger-importer-blogitem.php
@@ -108,7 +108,7 @@ if (!class_exists('WP_SimplePie_Blog_Item'))
         }
 
         //Don't Sanitize the ID, the default get_id was cleaning our IDs and that meant that nested comments did not work
-        function get_id($hash = false)
+        function get_id($hash = false, $fn = 'md5')
         {
             if ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'id'))
             {


### PR DESCRIPTION
Updates extended class `WP_SimplePie_Blog_Item::get_id()` to match [corresponding SimplePie v1.5 update](https://github.com/simplepie/simplepie/blob/1.5/library/SimplePie/Item.php#L212).

- Core SimplePie was updated in [d12ad50](https://github.com/WordPress/wordpress-develop/commit/d12ad5050b9795b2ef39391c6e60dc8b1eb542ec#diff-d8203c999641405857f9d5a432d7a748dbcfd199a7c84fa517437a27bd44f0d6), where [the signature for `SimplePie_Item::get_item()` was changed](https://github.com/WordPress/wordpress-develop/blame/d12ad5050b9795b2ef39391c6e60dc8b1eb542ec/src/wp-includes/SimplePie/Item.php#L210).
- Error caused by non-matching signature ([violates LSP](https://php.watch/versions/8.0/lsp-errors#class)), which in PHP 8 is fatal (previously only issued a warning).

Addresses: #1

Trac ticket: https://core.trac.wordpress.org/ticket/52084