### PR TITLE
PHP 7 deprecation notice due to old style (PHP 4) constructor name

### DIFF
--- a/blogger-importer.php
+++ b/blogger-importer.php
@@ -54,8 +54,6 @@ class Blogger_Importer extends WP_Importer {
 	var $processed_authors = array();
 	var $author_mapping = array();
 
-	function __construct() { /* nothing */ }
-
 	/**
 	 * Registered callback function for the Blogger Importer
 	 *

--- a/blogger-importer.php
+++ b/blogger-importer.php
@@ -54,7 +54,7 @@ class Blogger_Importer extends WP_Importer {
 	var $processed_authors = array();
 	var $author_mapping = array();
 
-	function Blogger_Importer() { /* nothing */ }
+	function __construct() { /* nothing */ }
 
 	/**
 	 * Registered callback function for the Blogger Importer


### PR DESCRIPTION
Resolves deprecation notice in PHP 7 where class `Blogger_Importer` constructor has same name as class. E.g.

<blockquote>
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; Blogger_Importer has a deprecated constructor in ../blogger-importer/blogger-importer.php on line 44
</blockquote>

### Background
- PHP 5 [introduced the `__construct()` method](https://www.php.net/manual/en/language.oop5.decon.php), but continued to allow "old style" PHP 4 constructors.
- PHP 7 [began to emit `E_DEPRECATED` whenever a PHP 4 constructor was defined](https://wiki.php.net/rfc/remove_php4_constructors).
- PHP 8 stops emitting `E_DEPRECATED`, and the same named methods will not be recognized as constructors.

Trac ticket: https://core.trac.wordpress.org/ticket/49143