### PR TITLE
Align with American English Suffix "-ize"

### DIFF
--- a/blogger-importer-sanitize.php
+++ b/blogger-importer-sanitize.php
@@ -49,7 +49,7 @@ class Blogger_Importer_Sanitize extends SimplePie_Sanitize
         //Simplified function
         $data = trim($data);
         
-        // Normalise tags (string replacement is case sensitive)
+        // Normalize tags (string replacement is case sensitive)
         $data = preg_replace_callback('|<(/?[A-Z]+)|', array(&$this, '_normalize_tag'), $data);
 
         // Remappings

--- a/blogger-importer.php
+++ b/blogger-importer.php
@@ -592,7 +592,7 @@ class Blogger_Importer extends WP_Importer {
 
 		if ($large) {
 			// For images on blogger we can swap /sXXX/ with for example /s1600/ to get a larger file.
-			// Use a standardised large size so we can control quality vs filesize.
+			// Use a standardized large size so we can control quality vs filesize.
 			$pattern = '/(\/)(s\d*)(\/)/i';
 			$replacement = '$1s'.Blogger_Importer::LARGE_IMAGE_SIZE.
 			'$3';


### PR DESCRIPTION
Update use of "-ise" suffix to American English "-ize" in comments. Checked for `(normal|standard|initial|color|colour)ise`.

Trac ticket: https://core.trac.wordpress.org/ticket/56811