### PR TITLE
Add support for WordPress 6.1

### DIFF
--- a/blogger-importer.php
+++ b/blogger-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/blogger-importer/
 Description: Import posts, comments, and categories from a Blogger blog and migrate authors to WordPress users.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.9
+Version: 0.9.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: blogger-importer

--- a/blogger-importer.php
+++ b/blogger-importer.php
@@ -21,7 +21,11 @@ define( 'IMPORT_DEBUG', false );
 // Load Importer API
 require_once ABSPATH . 'wp-admin/includes/import.php';
 
-require_once ABSPATH . WPINC . '/class-feed.php';
+if ( version_compare( get_bloginfo('version'), '4.7.0', '>=' ) ) {
+    require_once ABSPATH . WPINC . '/class-simplepie.php';
+} else {
+    require_once ABSPATH . WPINC . '/class-feed.php';
+}
 
 // Custom classes used by importer
 require_once dirname( __FILE__ ) . '/blogger-importer-sanitize.php';
@@ -42,17 +46,26 @@ if ( ! class_exists( 'WP_Importer' ) ) {
  */
 if ( !class_exists( 'Blogger_Importer' ) ) {
 class Blogger_Importer extends WP_Importer {
-	const IMPORT_IMG = true;         // Should we import the images (boolean)
+	const IMPORT_IMG       = true; // Should we import the images (boolean)
 	const LARGE_IMAGE_SIZE = '1024'; // The size of large images downloaded (string)
-	const POST_PINGBACK = 0;         // Turn off the post pingback, set to 1 to re-enabled(bool)
+	const POST_PINGBACK    = 0; // Turn off the post pingback, set to 1 to re-enabled(bool)
 
-	var $id; // XML attachment ID
-
-	var $authors = array();
-
-	// mappings from old information to new
-	var $processed_authors = array();
-	var $author_mapping = array();
+	private $id                = null; // XML attachment ID
+	private $author_mapping    = array();
+	private $authors           = array();
+	private $comments_done     = 0;
+	private $comments_skipped  = 0;
+	private $host              = null;
+	private $images_done       = 0;
+	private $images_progress   = 0;
+	private $images_skipped    = 0;
+	private $import_data       = null;
+	private $links_done        = 0;
+	private $links_progress    = 0;
+	private $posts_done        = 0;
+	private $posts_skipped     = 0;
+	private $processed_authors = array();
+	private $version           = null;
 
 	/**
 	 * Registered callback function for the Blogger Importer
@@ -140,11 +153,11 @@ class Blogger_Importer extends WP_Importer {
 		}
 
 		$this->import_data = $import_data;
-		
+
 		// <link rel='alternate' type='text/html' href='http://example.blogspot.com/'/>
 		$links = $import_data->get_links('alternate');
 		$this->host = parse_url($links[0], PHP_URL_HOST);
-		
+
 		$this->images_progress = 0;
 		$this->images_skipped = 0;
 		$this->links_done = 0;
@@ -199,7 +212,7 @@ class Blogger_Importer extends WP_Importer {
 
 		$this->id = (int) $file['id'];
 		$import_data = $file['file'];
-		
+
 		if ( is_wp_error( $import_data ) ) {
 			echo '<p><strong>' . __( 'Sorry, there has been an error.', 'blogger-importer' ) . '</strong><br />';
 			echo esc_html( $import_data->get_error_message() ) . '</p>';
@@ -217,9 +230,9 @@ class Blogger_Importer extends WP_Importer {
 	 * @param array $import_data Data returned by a WXR parser
 	 */
 	function get_authors_from_import( $import_data ) {
-		
+
 		$feed = $this->parse($import_data);
-		
+
 		$authors = $feed->get_authors();
 
 		foreach ($authors as $author) {
@@ -350,7 +363,7 @@ class Blogger_Importer extends WP_Importer {
 	 */
 	function process_posts() {
 		$feed = $this->import_data;
-		
+
 		foreach ( $feed->get_items() as $item ) {
 			// check that it is actually a post first
 			// <category scheme='http://schemas.google.com/g/2005#kind' term='http://schemas.google.com/blogger/2008/kind#post'/>
@@ -362,7 +375,7 @@ class Blogger_Importer extends WP_Importer {
 					break;
 				}
 			}
-			
+
 			// only import posts for now
 			if ( ! $is_post ) {
 				continue;
@@ -378,7 +391,7 @@ class Blogger_Importer extends WP_Importer {
 			$blogentry->title = $item->get_title();
 			$blogentry->content = $item->get_content();
 			$blogentry->geotags = $item->get_geotags();
-			
+
 			// map the post author
 			$blogentry->bloggerauthor = sanitize_user( $item->get_author()->get_name(), true );
 			if ( isset( $this->author_mapping[$blogentry->bloggerauthor] ) )
@@ -388,7 +401,7 @@ class Blogger_Importer extends WP_Importer {
 
 			$blogentry->links = $item->get_links(array('replies', 'edit', 'self', 'alternate'));
 			$blogentry->parselinks();
-			
+
 			foreach ( $cats as $cat ) {
 				if ( false === strpos( $cat, 'http://schemas.google.com') ) {
 					$blogentry->categories[] = $cat;
@@ -405,7 +418,7 @@ class Blogger_Importer extends WP_Importer {
 				$post_id = $blogentry->import();
 				$this->posts_done++;
 			}
-		}                
+		}
 	}
 
 	/**
@@ -413,7 +426,7 @@ class Blogger_Importer extends WP_Importer {
 	 */
 	function process_comments() {
 		$feed = $this->import_data;
-		
+
 		foreach ( $feed->get_items() as $item ) {
 			// check that it is actually a comment first
 			// <category scheme='http://schemas.google.com/g/2005#kind' term='http://schemas.google.com/blogger/2008/kind#comment'/>
@@ -425,12 +438,12 @@ class Blogger_Importer extends WP_Importer {
 					break;
 				}
 			}
-			
+
 			// we only import comments here
 			if ( ! $is_comment ) {
 				continue;
 			}
-			
+
 			$commententry = new CommentEntry();
 
 			$commententry->id = $item->get_id();
@@ -439,10 +452,10 @@ class Blogger_Importer extends WP_Importer {
 			$commententry->author = $item->get_author()->get_name();
 			$commententry->authoruri = $item->get_author()->get_link();
 			$commententry->authoremail = $item->get_author()->get_email();
-			
+
 			$replyto = $item->get_item_tags('http://purl.org/syndication/thread/1.0','in-reply-to');
 			$commententry->source = $replyto[0]['attribs']['']['source'];
-			
+
 			$commententry->source = $item->get_source();
 			$parts = parse_url($commententry->source);
 			$commententry->old_post_permalink = $parts['path']; //Will be something like this '/feeds/417730729915399755/posts/default/8397846992898424746'
@@ -471,14 +484,14 @@ class Blogger_Importer extends WP_Importer {
 			} else {
 				$this->comments_skipped++;
 			}
-		}                
+		}
 	}
 
 	/*
 	* Search for either a linked image or a non linked image within the supplied html
 	* <a href="xxx" yyyy><img src="zzz" ></a> or <img src="zzz" >
 	* Ref: http://www.the-art-of-web.com/php/parse-links/
-	*        "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>"  
+	*        "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>"
 	*      http://wordpress.org/extend/plugins/blogger-image-import/
 	*        "<a[^>]+href\=([\"'`])(.*)\\1[^<]*?<img[^>]*src\=([\"'`])(.*)\\3[^>]*>"
 	*/
@@ -509,7 +522,7 @@ class Blogger_Importer extends WP_Importer {
 				$lowrez[$match[2]] = '';
 			}
 		}
-		
+
 		//Remove any rows from this second set that are already in the first set and merge two sets of results
 		$images = array_merge($lowrez, $highrez);
 		return $images;
@@ -531,10 +544,10 @@ class Blogger_Importer extends WP_Importer {
 		$batchsize = 20;
 
 		$loadedposts = get_posts( array(
-			'meta_key' => 'blogger_blog', 
-			'meta_value' => $this->host, 
-			'posts_per_page' => $batchsize, 
-			'offset' => $postsprocessed, 
+			'meta_key' => 'blogger_blog',
+			'meta_value' => $this->host,
+			'posts_per_page' => $batchsize,
+			'offset' => $postsprocessed,
 			'post_status' => array('draft', 'publish', 'future')
 		));
 
@@ -618,7 +631,7 @@ class Blogger_Importer extends WP_Importer {
 		or
 		<img src="mylowrezimage.jpg">
 
-		If the high resolution (linked) file is not an image then the low resolution version is downloaded.           
+		If the high resolution (linked) file is not an image then the low resolution version is downloaded.
 		*/
 		$lowrez_old = $lowrez;
 		$highrez_old = $highrez;
@@ -666,7 +679,7 @@ class Blogger_Importer extends WP_Importer {
 			if ( empty( $description ) ) {
 				$description = $new_name;
 			}
-			
+
 			$att_id = media_handle_sideload($file_array, $post_id, $description);
 			if (is_wp_error($att_id)) {
 				@unlink($file_array['tmp_name']);
@@ -735,7 +748,7 @@ class Blogger_Importer extends WP_Importer {
 		return $wpdb->get_var($wpdb->prepare("SELECT ID FROM $wpdb->posts p INNER JOIN $wpdb->postmeta m ON p.ID = m.post_id AND meta_key = 'blogger_permalink' WHERE post_type = 'attachment' AND meta_value = %s LIMIT 0 , 1",
 			$lowrez));
 	}
-	
+
         function process_links() {
 		//Update all of the links in the blog
 		global $wpdb;
@@ -842,7 +855,11 @@ class Blogger_Importer extends WP_Importer {
 	// Display import page title
 	function header() {
 		echo '<div class="wrap">';
-		screen_icon();
+
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
+			screen_icon();
+		}
+
 		echo '<h2>' . __( 'Import Blogger', 'blogger-importer' ) . '</h2>';
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Blogger Importer ===
 Contributors: wordpressdotorg, Otto42, Workshopshed, SergeyBiryukov, rmccue
-Donate link: 
+Donate link:
 Tags: importer, blogger
 Requires at least: 3.0
-Tested up to: 4.3
-Stable tag: 0.9
+Tested up to: 6.1
+Stable tag: 0.9.1
 License: GPLv2 or later
 
 Imports posts, images, comments, and categories (blogger tags) from a Blogger blog then migrates authors to WordPress users.
@@ -34,7 +34,7 @@ The Blogger Importer imports your blog data from a Google Blogger site into a Wo
 
 = Prerequisites =
 
-The importer connects your server to the blogger server to copy across the posts. For this to work you need to have connectivity from the server to the internet and also have at least one of the remote access protocols enabled, e.g. curl, streams or fsockopen. You can use the Core Control plugin to test if these are working correctly. The importer connects to Google over a secure connection so OpenSSL needs to be enabled on your server. 
+The importer connects your server to the blogger server to copy across the posts. For this to work you need to have connectivity from the server to the internet and also have at least one of the remote access protocols enabled, e.g. curl, streams or fsockopen. You can use the Core Control plugin to test if these are working correctly. The importer connects to Google over a secure connection so OpenSSL needs to be enabled on your server.
 The importer uses the SimplePie classes to read and process the data from blogger so you will need the php-xml module installed on your webserver.
 
 = Preparation =
@@ -62,7 +62,7 @@ Simply upload the XML file again. Already imported posts will be skipped and not
 
 No, you can remove the plugin once you've completed your migration.
 
-= How do I know which posts were imported? = 
+= How do I know which posts were imported? =
 
 Each of the posts loaded is tagged with a meta tags indicating where the posts were loaded from. The permalink will be set to the visible URL if the post was published or the internal ID if it was still a draft or scheduled post
 
@@ -84,7 +84,7 @@ This version of the importer imports these too, but you can disable this via a s
 
 = What size are the images? =
 
-The importer will attempt to download the a large version of the file if one is available. This is controlled by the setting "LARGE_IMAGE_SIZE" and defaults to a width of 1024. The display size of the images is the "medium" size of images as defined on WordPress. You can change this in advance if you want to show a different size. 
+The importer will attempt to download the a large version of the file if one is available. This is controlled by the setting "LARGE_IMAGE_SIZE" and defaults to a width of 1024. The display size of the images is the "medium" size of images as defined on WordPress. You can change this in advance if you want to show a different size.
 
 = How do I know what images are skipped? =
 
@@ -100,7 +100,7 @@ No, WordPress and Blogger handle the permalinks differently. However, it is poss
 
 = My posts and comments moved across but some things are stripped out =
 
-The importer uses the SimplePie classes to process the data, these in turn use a Simplepie_Sanitize class to remove potentially malicious code from the source data. If the php-xml module is not installed then this may result in your entire comment text being stripped out and the error "PHP Warning: DOMDocument not found, unable to use sanitizer" to appear in your logs. 
+The importer uses the SimplePie classes to process the data, these in turn use a Simplepie_Sanitize class to remove potentially malicious code from the source data. If the php-xml module is not installed then this may result in your entire comment text being stripped out and the error "PHP Warning: DOMDocument not found, unable to use sanitizer" to appear in your logs.
 
 = The comments don't have avatars =
 
@@ -112,19 +112,19 @@ The most common reasons for this are lack of memory and timeouts, these should a
 
 = How do I make the images bigger or smaller? / My images are fuzzy =
 
-The importer will attempt to download a large version of images but it displays them on the blog at the medium size. If you go into your settings->media options then you can display a different size "medium" image by default. You can't make this bigger than the file that has been downloaded which is where the next setting comes in.  
+The importer will attempt to download a large version of images but it displays them on the blog at the medium size. If you go into your settings->media options then you can display a different size "medium" image by default. You can't make this bigger than the file that has been downloaded which is where the next setting comes in.
 
-The default size for the large images is 1024, you can change this to an even larger size by changing the following line in the blogger-import.php file. 
+The default size for the large images is 1024, you can change this to an even larger size by changing the following line in the blogger-import.php file.
 
 const LARGE_IMAGE_SIZE = '1024';
 
 The file downloaded won't be bigger than the origional file so if it was only 800x600 to start with then it won't be any bigger than that.
 
-If your origional blog has hardcoded width and height values that are larger than the medium size settings then that might result in your images becoming fuzzy. 
+If your origional blog has hardcoded width and height values that are larger than the medium size settings then that might result in your images becoming fuzzy.
 
-= I've run out of disk space processing the images = 
+= I've run out of disk space processing the images =
 
-The importer is designed to download the high resolution images where they are available. You can either disable the downloading of images or you can change the constant LARGE_IMAGE_SIZE string in the blogger-importer.php file to swap the links with a smaller image. 
+The importer is designed to download the high resolution images where they are available. You can either disable the downloading of images or you can change the constant LARGE_IMAGE_SIZE string in the blogger-importer.php file to swap the links with a smaller image.
 
 == Reference ==
 
@@ -134,7 +134,7 @@ The following were referenced for implementing the images and links
 
 * http://wordpress.org/extend/plugins/remote-images-grabber
 * http://notions.okuda.ca/wordpress-plugins/blogger-image-import/
-* http://wordpress.org/extend/plugins/cache-images/ 
+* http://wordpress.org/extend/plugins/cache-images/
 * http://wordpress.org/extend/plugins/tumblr-importer/
 * http://core.trac.wordpress.org/ticket/14525
 * http://wpengineer.com/1735/easier-better-solutions-to-get-pictures-on-your-posts/
@@ -164,6 +164,9 @@ Filter - blogger_importer_congrats - Passes the list of options shown to the use
 
 == Changelog ==
 
+= 0.9.1 =
+* Add support for WordPress 6.1
+
 = 0.9 =
 * Complete rewrite to use XML files instead.
 
@@ -176,11 +179,11 @@ Filter - blogger_importer_congrats - Passes the list of options shown to the use
 * Simplified functions to reduce messages in the log
 
 = 0.7 =
-* Fixed issue with drafts not being imported in the right state 
+* Fixed issue with drafts not being imported in the right state
 * Added extra error handling for get_oauth_link to stop blank tokens being sent to the form
 * Restructured code to keep similar steps in single function and to allow testing of components to be done
 * Re-incorporated the "congrats" function and provided a sensible list of what to do next
-* Add a geo_public flag to posts with geotags 
+* Add a geo_public flag to posts with geotags
 * Dropped _normalize_tag after confirming that it's handled by SimplePie
 * Added image handling http://core.trac.wordpress.org/ticket/4010
 * Added setting author on images
@@ -220,9 +223,9 @@ Filter - blogger_importer_congrats - Passes the list of options shown to the use
 * Tested comments from source blog GMT-8, destination London (currently GMT-1), comment dates transferred correctly.
 * Fixed typo in oauth_get
 * Added screen_icon() to all pages
-* Added GeoTags as per spec on http://codex.wordpress.org/Geodata 
+* Added GeoTags as per spec on http://codex.wordpress.org/Geodata
 * Change by Otto42, rmccue to use Simplepie XML processing rather than Atomparser, http://core.trac.wordpress.org/ticket/14525 ref: http://core.trac.wordpress.org/attachment/ticket/7652/7652-blogger.diff
-  this also fixes http://core.trac.wordpress.org/ticket/15560 
+  this also fixes http://core.trac.wordpress.org/ticket/15560
 * Change by Otto42 to use OAuth rather than AuthSub authentication, should make authentication more reliable
 * Fix by Andy from Workshopshed to load comments and nested comments correctly
 * Fix by Andy from Workshopshed to correctly pass the blogger start-index and max-results parameters to oAuth functions and to process more than one batch http://core.trac.wordpress.org/ticket/19096


### PR DESCRIPTION
This PR fixes the plugins and adds support for WordPress `6.1` and upgrades the plugin to `0.9.1`.

(Related Trac ticket: https://core.trac.wordpress.org/ticket/56856.)

- Tested with WordPress `6.1`
- Tested with PHP `7.4.33`
- The `screen_icon` function is now deprecated. Added a check for WordPress `3.8.0`
- `ABSPATH . WPINC . '/class-feed.php'` is a deprecated file. Added a check for WordPress `4.7.0`
- Declared all class variables
- Removed all trailing whitespaces

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **Blogger Importer**
5. Open `http://localhost/wp-admin/admin.php?import=blogger`
6. Open a sample XML. The plugin must load correctly and no errors displayed

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/blogger-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
