### PR TITLE
Call process_images in a loop until they are all done.

### DIFF
--- a/blogger-importer.php
+++ b/blogger-importer.php
@@ -115,7 +115,9 @@ class Blogger_Importer extends WP_Importer {
 
 		if (Blogger_Importer::IMPORT_IMG)
 		{
-			$this->process_images();
+            do {
+                $finished = $this->process_images();
+            } while(!$finished);
 		}
 
 		$this->process_links();

--- a/blogger-importer.php
+++ b/blogger-importer.php
@@ -115,9 +115,9 @@ class Blogger_Importer extends WP_Importer {
 
 		if (Blogger_Importer::IMPORT_IMG)
 		{
-            do {
-                $finished = $this->process_images();
-            } while(!$finished);
+			do {
+				$finished = $this->process_images();
+			} while(!$finished);
 		}
 
 		$this->process_links();


### PR DESCRIPTION
This PR closes https://github.com/WordPress/blogger-importer/issues/10 by putting the call to `process_images` in a loop until all the images are done.